### PR TITLE
第二次merge到master，添加并优化了部分接口

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
@@ -37,7 +36,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/example/backend/EntityDetailsPack/EntityController.java
+++ b/src/main/java/com/example/backend/EntityDetailsPack/EntityController.java
@@ -1,0 +1,32 @@
+package com.example.backend.EntityDetailsPack;
+import com.example.backend.PersonalInterface.BackendLogin;
+import com.example.backend.PersonalInterface.QuickMap;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+import java.util.HashMap;
+
+@Controller
+@RequestMapping(path="/entity")
+public class EntityController implements QuickMap, BackendLogin {
+    static String id = null;
+    @GetMapping(path="/course")
+    public @ResponseBody HashMap EntityDetails (@RequestParam String course
+            , @RequestParam String name) {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://open.edukg.cn/opedukg/api/typeOpen/open/infoByInstanceName?course={course}&name={name}&id={id}";
+        if (id == null) id = BackendLogin.getOpeneduID();
+        HashMap response = restTemplate.getForObject(url, HashMap.class, QuickMap.createMap("course", course, "name", name, "id", id));
+        HashMap data = (HashMap) response.get("data");
+        return data;
+    }
+    @GetMapping(path="/ncourse")
+    public @ResponseBody HashMap EntityDetails (@RequestParam String name) {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://open.edukg.cn/opedukg/api/typeOpen/open/infoByInstanceName?name={name}&id={id}";
+        if (id == null) id = BackendLogin.getOpeneduID();
+        HashMap response = restTemplate.getForObject(url, HashMap.class, QuickMap.createMap("name", name, "id", id));
+        HashMap data = (HashMap) response.get("data");
+        return data;
+    }
+}

--- a/src/main/java/com/example/backend/EntitySearchPack/SearchController.java
+++ b/src/main/java/com/example/backend/EntitySearchPack/SearchController.java
@@ -1,12 +1,9 @@
 package com.example.backend.EntitySearchPack;
 import com.example.backend.PersonalInterface.BackendLogin;
 import com.example.backend.PersonalInterface.QuickMap;
-import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.http.HttpHeaders;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -15,8 +12,8 @@ import java.util.HashMap;
 public class SearchController implements QuickMap, BackendLogin {
     static String id = null;
 
-    @GetMapping(path="/entity") // Map ONLY POST Requests
-    public @ResponseBody ArrayList mySearch (@RequestParam String course
+    @GetMapping(path="/entity")
+    public @ResponseBody ArrayList EntitySearch (@RequestParam String course
             , @RequestParam String searchKey) {
         RestTemplate restTemplate = new RestTemplate();
         String url = "http://open.edukg.cn/opedukg/api/typeOpen/open/instanceList?course={course}&searchKey={searchKey}&id={id}";

--- a/src/main/java/com/example/backend/EntitySearchPack/SearchController.java
+++ b/src/main/java/com/example/backend/EntitySearchPack/SearchController.java
@@ -1,4 +1,5 @@
 package com.example.backend.EntitySearchPack;
+import com.example.backend.PersonalInterface.BackendLogin;
 import com.example.backend.PersonalInterface.QuickMap;
 import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Controller;
@@ -11,14 +12,15 @@ import java.util.HashMap;
 
 @Controller
 @RequestMapping(path="/search")
-public class SearchController implements QuickMap {
+public class SearchController implements QuickMap, BackendLogin {
+    static String id = null;
+
     @GetMapping(path="/entity") // Map ONLY POST Requests
     public @ResponseBody ArrayList mySearch (@RequestParam String course
-            , @RequestParam String searchKey, @RequestParam String id) {
+            , @RequestParam String searchKey) {
         RestTemplate restTemplate = new RestTemplate();
         String url = "http://open.edukg.cn/opedukg/api/typeOpen/open/instanceList?course={course}&searchKey={searchKey}&id={id}";
-        HttpHeaders headers = new HttpHeaders();
-        HttpEntity entity = new HttpEntity(null, headers);
+        if (id == null) id = BackendLogin.getOpeneduID();
         HashMap response = restTemplate.getForObject(url, HashMap.class, QuickMap.createMap("course", course, "searchKey", searchKey, "id", id));
         ArrayList data = (ArrayList) response.get("data");
         return data;

--- a/src/main/java/com/example/backend/ExercisesSearchPack/ExercisesController.java
+++ b/src/main/java/com/example/backend/ExercisesSearchPack/ExercisesController.java
@@ -1,15 +1,11 @@
 package com.example.backend.ExercisesSearchPack;
 import com.example.backend.PersonalInterface.BackendLogin;
 import com.example.backend.PersonalInterface.QuickMap;
-import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.http.HttpHeaders;
-
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 
 @Controller
 @RequestMapping(path="/search")
@@ -17,8 +13,8 @@ public class ExercisesController implements QuickMap, BackendLogin {
     static String id = null;
 
 
-    @GetMapping(path="/exercises") // Map ONLY POST Requests
-    public @ResponseBody ArrayList mySearch (@RequestParam String uriName) {
+    @GetMapping(path="/exercises")
+    public @ResponseBody ArrayList ExercisesSearch (@RequestParam String uriName) {
         RestTemplate restTemplate = new RestTemplate();
         String url = "http://open.edukg.cn/opedukg/api/typeOpen/open/questionListByUriName?uriName={uriName}&id={id}";
         if (id == null) id = BackendLogin.getOpeneduID();

--- a/src/main/java/com/example/backend/ExercisesSearchPack/ExercisesController.java
+++ b/src/main/java/com/example/backend/ExercisesSearchPack/ExercisesController.java
@@ -1,4 +1,5 @@
 package com.example.backend.ExercisesSearchPack;
+import com.example.backend.PersonalInterface.BackendLogin;
 import com.example.backend.PersonalInterface.QuickMap;
 import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Controller;
@@ -12,13 +13,15 @@ import java.util.List;
 
 @Controller
 @RequestMapping(path="/search")
-public class ExercisesController implements QuickMap {
+public class ExercisesController implements QuickMap, BackendLogin {
+    static String id = null;
+
+
     @GetMapping(path="/exercises") // Map ONLY POST Requests
-    public @ResponseBody ArrayList mySearch (@RequestParam String uriName, @RequestParam String id) {
+    public @ResponseBody ArrayList mySearch (@RequestParam String uriName) {
         RestTemplate restTemplate = new RestTemplate();
         String url = "http://open.edukg.cn/opedukg/api/typeOpen/open/questionListByUriName?uriName={uriName}&id={id}";
-        HttpHeaders headers = new HttpHeaders();
-        HttpEntity entity = new HttpEntity(null, headers);
+        if (id == null) id = BackendLogin.getOpeneduID();
         HashMap response = restTemplate.getForObject(url, HashMap.class, QuickMap.createMap("uriName", uriName, "id", id));
         ArrayList data = (ArrayList) response.get("data");
 //        for (int i=0; i<data.size(); i++) {

--- a/src/main/java/com/example/backend/PassWordEncoder/PasswordEncoder.java
+++ b/src/main/java/com/example/backend/PassWordEncoder/PasswordEncoder.java
@@ -1,0 +1,15 @@
+package com.example.backend.PassWordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.DigestUtils;
+
+@Component
+public class PasswordEncoder{
+    public static String encode(String rawPassword) {
+        System.out.println(rawPassword);
+        System.out.println(DigestUtils.md5DigestAsHex(rawPassword.getBytes()));
+        return DigestUtils.md5DigestAsHex(rawPassword.getBytes());
+    }
+    public static boolean matches(String rawPassword, String encodedPassword) {
+        return encodedPassword.equals(DigestUtils.md5DigestAsHex(rawPassword.getBytes()));
+    }
+}

--- a/src/main/java/com/example/backend/PassWordEncoder/PasswordEncoder.java
+++ b/src/main/java/com/example/backend/PassWordEncoder/PasswordEncoder.java
@@ -5,8 +5,6 @@ import org.springframework.util.DigestUtils;
 @Component
 public class PasswordEncoder{
     public static String encode(String rawPassword) {
-        System.out.println(rawPassword);
-        System.out.println(DigestUtils.md5DigestAsHex(rawPassword.getBytes()));
         return DigestUtils.md5DigestAsHex(rawPassword.getBytes());
     }
     public static boolean matches(String rawPassword, String encodedPassword) {

--- a/src/main/java/com/example/backend/PersonalInterface/BackendLogin.java
+++ b/src/main/java/com/example/backend/PersonalInterface/BackendLogin.java
@@ -1,11 +1,9 @@
 package com.example.backend.PersonalInterface;
-
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
-
 import java.util.HashMap;
 
 public interface BackendLogin {

--- a/src/main/java/com/example/backend/PersonalInterface/BackendLogin.java
+++ b/src/main/java/com/example/backend/PersonalInterface/BackendLogin.java
@@ -1,0 +1,26 @@
+package com.example.backend.PersonalInterface;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+
+public interface BackendLogin {
+    static String getOpeneduID () {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "http://open.edukg.cn/opedukg/api/typeAuth/user/login";
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity entity = new HttpEntity(QuickMap.createMap("password", "13603959776Zhp", "phone", "18839551859"), headers);
+        ResponseEntity response = null;
+        try {
+            response = restTemplate.exchange(url, HttpMethod.POST, entity, HashMap.class);
+        } catch (Exception e) {
+            return "OpenEdu又挂了！";
+        }
+        HashMap<String, String> data = (HashMap<String, String>) response.getBody();
+        return data.get("id");
+    }
+}

--- a/src/main/java/com/example/backend/PersonalInterface/QuickMap.java
+++ b/src/main/java/com/example/backend/PersonalInterface/QuickMap.java
@@ -1,5 +1,4 @@
 package com.example.backend.PersonalInterface;
-
 import java.util.HashMap;
 
 public interface QuickMap {

--- a/src/main/java/com/example/backend/QAbot/QuestionController.java
+++ b/src/main/java/com/example/backend/QAbot/QuestionController.java
@@ -1,5 +1,4 @@
 package com.example.backend.QAbot;
-
 import com.example.backend.PersonalInterface.BackendLogin;
 import com.example.backend.PersonalInterface.QuickMap;
 import org.springframework.http.HttpEntity;
@@ -9,7 +8,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
-
 import java.util.HashMap;
 
 @Controller

--- a/src/main/java/com/example/backend/QAbot/QuestionController.java
+++ b/src/main/java/com/example/backend/QAbot/QuestionController.java
@@ -1,5 +1,6 @@
 package com.example.backend.QAbot;
 
+import com.example.backend.PersonalInterface.BackendLogin;
 import com.example.backend.PersonalInterface.QuickMap;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -9,20 +10,24 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.HashMap;
+
 @Controller
 @RequestMapping(path="")
-public class QuestionController implements QuickMap {
-    @GetMapping(path="/clientquestion") // Map ONLY POST Requests
-    public @ResponseBody
-    String mySearch (@RequestParam String course
-            , @RequestParam String inputQuestion, @RequestParam String id) {
+public class QuestionController implements QuickMap, BackendLogin {
+    static String id = null;
+
+    @GetMapping(path="/clientquestion")
+    public @ResponseBody String mySearch (@RequestParam String course
+            , @RequestParam String inputQuestion) {
         RestTemplate restTemplate = new RestTemplate();
         String url = "http://open.edukg.cn/opedukg/api/typeOpen/open/inputQuestion";
         HttpHeaders headers = new HttpHeaders();
+        if (id == null) id = BackendLogin.getOpeneduID();
         HttpEntity entity = new HttpEntity(QuickMap.createMap("course", course, "inputQuestion", inputQuestion, "id", id), headers);
         ResponseEntity response = null;
         try {
-            response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
+            response = restTemplate.exchange(url, HttpMethod.POST, entity, HashMap.class);
             if (response.getStatusCodeValue()!=200) return "发生未知错误，请稍后重试";
         } catch (Exception e) {
             return "发生未知错误，请稍后重试";

--- a/src/main/java/com/example/backend/User/MainController.java
+++ b/src/main/java/com/example/backend/User/MainController.java
@@ -37,6 +37,8 @@ public class MainController {
     public @ResponseBody String userLogin (@RequestParam String name
             , @RequestParam String password) {
         List<User> list = userDao.getUserByname(name);
+        System.out.println(name);
+        System.out.println(password);
         if (list.isEmpty()) {
             return "未找到用户名";
         } else if (!list.get(0).getPassword().equals(password)) {

--- a/src/main/java/com/example/backend/User/MainController.java
+++ b/src/main/java/com/example/backend/User/MainController.java
@@ -1,4 +1,5 @@
 package com.example.backend.User;
+import com.example.backend.PassWordEncoder.PasswordEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -17,6 +18,7 @@ public class MainController {
         List<User> list = userDao.getUserByname(name);
         if (list.isEmpty()) {
             User n = new User();
+            password = PasswordEncoder.encode(password);
             n.init(name, password, email);
             userDao.save(n);
             return "注册成功";
@@ -41,7 +43,7 @@ public class MainController {
         System.out.println(password);
         if (list.isEmpty()) {
             return "未找到用户名";
-        } else if (!list.get(0).getPassword().equals(password)) {
+        } else if (!PasswordEncoder.matches(password, list.get(0).getPassword())) {
             return "密码错误";
         } else {
             return "登录成功";

--- a/src/main/java/com/example/backend/User/MainController.java
+++ b/src/main/java/com/example/backend/User/MainController.java
@@ -3,7 +3,6 @@ import com.example.backend.PassWordEncoder.PasswordEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 
 @Controller
@@ -39,8 +38,6 @@ public class MainController {
     public @ResponseBody String userLogin (@RequestParam String name
             , @RequestParam String password) {
         List<User> list = userDao.getUserByname(name);
-        System.out.println(name);
-        System.out.println(password);
         if (list.isEmpty()) {
             return "未找到用户名";
         } else if (!PasswordEncoder.matches(password, list.get(0).getPassword())) {

--- a/src/main/java/com/example/backend/User/User.java
+++ b/src/main/java/com/example/backend/User/User.java
@@ -1,9 +1,8 @@
 package com.example.backend.User;
-
 import javax.persistence.*;
 import java.io.Serializable;
 
-@Entity // This tells Hibernate to make a table out of this class
+@Entity
 @Table(name = "users")
 public class User implements Serializable {
     @Id
@@ -30,7 +29,7 @@ public class User implements Serializable {
 
     public void init(String name, String password, String email) {
         this.name = name;
-        this.password = password; // 之后会增加密码加密，暂时直接存储
+        this.password = password;
         this.email = email;
     }
 
@@ -45,7 +44,8 @@ public class User implements Serializable {
     public void setEmail(String email) {
         this.email = email;
     }
-    @Override
+
+    @Override //这个基本只有调试时使用
     public String toString() {
         return "Users [userid=" + id + ", username=" + name + ", email=" + email + "]";
     }

--- a/src/main/java/com/example/backend/User/UserDao.java
+++ b/src/main/java/com/example/backend/User/UserDao.java
@@ -1,13 +1,8 @@
 package com.example.backend.User;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.Repository;
-
 import java.util.List;
 
 public interface UserDao extends JpaRepository<User, Integer> {
-//    @Query("select u.id, u.name from User u where u.id = :id")
     List<User> getUserById(Integer id);
     List<User> getUserByemail(String email);
     List<User> getUserBypassword(String password);


### PR DESCRIPTION
目前已经实现：

    1. 用户注册、登录、删除、通过用户名查找、通过email查找等几个基本逻辑。密码加密部分已完成。
    注册：127.0.0.1:8010/user/register，方法为POST，所需参数为String name，String password和String email，返回String（调试用）。
    登录：127.0.0.1:8010/user/login，方法为POST，所需参数为String name和String password，返回String（调试用）
    删除：127.0.0.1:8010/user/deleteuser，方法为DELETE，应当在登录后调用，所需参数为String name，返回String（调试用）
    几个查找逻辑就不列出了。

    2. 智能问答机器人接口。然而openedu接口是挂的，还没测试，前端可以先写页面。
    127.0.0.1:8010/clientquestion，方法为GET，所需参数为String inputQuestion和String course（非必须），返回内容未知。

    3. 实体搜索API
    127.0.0.1:8010/search/entity，方法为GET，所需参数为String course和String searchKey，返回ArrayList。

    4. 习题搜索API
    127.0.0.1:8010/search/exercises，方法为GET，所需参数为String uriName，返回ArrayList。

    5. 实体详情API
    127.0.0.1:8010/entity/course，方法为GET，所需参数为String name和String course，返回HashMap。
    127.0.0.1:8010/entity/ncourse，因未知原因暂无法使用，方法为GET，所需参数为String name，返回HashMap。